### PR TITLE
Correct the autosort rules command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Sort rules use the following syntax:
 ```
 <glob-pattern> = <score>
 ```
-You can use the `/autosort rule` command to show and manipulate the list of sort rules.
+You can use the `/autosort rules` command to show and manipulate the list of sort rules.
 
 
 Allowed special characters in the glob patterns are:


### PR DESCRIPTION
The command listed "/autosort rule" didn't work for me, but "/autosort rules" did.
