### PR TITLE
Add rules to default rules for matrix buffers

### DIFF
--- a/autosort.py
+++ b/autosort.py
@@ -179,6 +179,9 @@ class Config:
 		'${if:${plugin}==irc?${server}}',
 		'${if:${plugin}==irc?${info:autosort_order,${type},server,*,channel,private}}',
 		'${if:${plugin}==irc?${hashless_name}}',
+		'${if:${plugin}==python?${server}}',
+		'${if:${plugin}==python?${info:autosort_order,${type},server,*,channel,private}}',
+		'${if:${plugin}==python?${hashless_name}}',
 		'${buffer.full_name}',
 	])
 


### PR DESCRIPTION
Copy over the IRC sorting rules for python modules for proper sorting of matrix (weechat-matrix.py) buffers.

/cc @de-vri-es as discussed on IRC 😄 